### PR TITLE
Run `solc` with flag `--optimize`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ Note that function selector is already included.
 ## Limitations
 
 - It only allows circuit with **exact 1 instance column** and **no rotated query to this instance column**.
-- Option `--via-ir` seems necessary when compiling the generated contract, otherwise it'd cause stack too deep error. However, `--via-ir` is not allowed to be used with `--standard-json`, not sure how to work around this yet.
-- Even the `configure` is same, the [selector compression](https://github.com/privacy-scaling-explorations/halo2/blob/7a2165617195d8baa422ca7b2b364cef02380390/halo2_proofs/src/plonk/circuit/compress_selectors.rs#L51) might lead to different configuration when selector assignments are different. To avoid this we might need to update halo2 to support disabling selector compression.
+- Currently even the `configure` is same, the [selector compression](https://github.com/privacy-scaling-explorations/halo2/blob/7a2165617195d8baa422ca7b2b364cef02380390/halo2_proofs/src/plonk/circuit/compress_selectors.rs#L51) might lead to different configuration when selector assignments are different. After PR https://github.com/privacy-scaling-explorations/halo2/pull/212 is merged we will have an alternative API to do key generation without selector compression.
 - Now it only supports BDFG21 batch open scheme (aka SHPLONK), GWC19 is not yet implemented.
 
 ## Compatibility

--- a/examples/separately.rs
+++ b/examples/separately.rs
@@ -45,7 +45,7 @@ fn main() {
         let calldata = {
             let instances = circuit.instances();
             let proof = create_proof_checked(&params[&k], &pk, circuit, &instances, &mut rng);
-            encode_calldata(vk_address.0.into(), &proof, &instances)
+            encode_calldata(Some(vk_address.into()), &proof, &instances)
         };
         let (gas_cost, output) = evm.call(verifier_address, calldata);
         assert_eq!(output, [vec![0; 31], vec![1]].concat());

--- a/src/evm.rs
+++ b/src/evm.rs
@@ -69,7 +69,7 @@ pub(crate) mod test {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .arg("--bin")
-            .arg("--via-ir")
+            .arg("--optimize")
             .arg("-")
             .spawn()
         {

--- a/src/test.rs
+++ b/src/test.rs
@@ -102,7 +102,7 @@ fn run_render_separately<C: halo2::TestCircuit<Fr>>() {
 
         let (gas_cost, output) = evm.call(
             verifier_address,
-            encode_calldata(vk_address.0.into(), &proof, &instances),
+            encode_calldata(Some(vk_address.into()), &proof, &instances),
         );
         assert_eq!(output, [vec![0; 31], vec![1]].concat());
         println!("Gas cost: {gas_cost}");


### PR DESCRIPTION
Switch to opcode-based optimizer after some trial-and-error and studying of the document (still don't understand how to 2 compilers compare but in general `--optmize` does a better job than `--via-ir` to make the contract size within limitation)