### PR TITLE
fix: verifyProof function marked as view

### DIFF
--- a/templates/Halo2Verifier.sol
+++ b/templates/Halo2Verifier.sol
@@ -78,7 +78,7 @@ contract Halo2Verifier {
         {%- endmatch %}
         bytes calldata proof,
         uint256[] calldata instances
-    ) public returns (bool) {
+    ) public view returns (bool) {
         assembly {
             // Read EC point (x, y) at (proof_cptr, proof_cptr + 0x20),
             // and check if the point is on affine plane,


### PR DESCRIPTION
Verify function on verifier smart contract should be defined as `view`, as it does not write on smart contract storage.
Closes #18 